### PR TITLE
Add option to remove desktop after focus change

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Below are the different configuration options available.  Please look at [exampl
 | min | Int | Minimum number of desktops per monitor | 1 |
 | max | Int | Maximum number of desktops per monitor | infinity |
 | remove-empty | Bool | Removes empty desktops | true |
+| remove-focused | Bool | Removes focused desktops | false |
 | append-when-occupied | Bool | Appends a new desktop when all other desktops are occupied | true |
 | watch-config | Bool | Reload btops on next event when configuration changes | true |
 | renamers | []String | Order of [renamers](#renamers) to use for renaming desktops. If a given renamer is unable to rename a desktop, it cascades to the next renmaer | ["numeric"]

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Min                int
 	Max                int
 	RemoveEmpty        bool `mapstructure:"remove-empty"`
+	RemoveFocused      bool `mapstructure:"remove-focused"`
 	AppendWhenOccupied bool `mapstructure:"append-when-occupied"`
 	WatchConfig        bool `mapstructure:"watch-config"`
 	configChangeC      chan bool
@@ -89,6 +90,7 @@ func newDefaultConfig() *viper.Viper {
 	c.SetDefault("min", 1)
 	c.SetDefault("max", math.MaxInt64)
 	c.SetDefault("remove-empty", true)
+	c.SetDefault("remove-focused", true)
 	c.SetDefault("append-when-occupied", true)
 	c.SetDefault("renamers", []string{numeric})
 	c.SetDefault("watch-config", true)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -134,11 +134,10 @@ func (r RemoveHandler) ShouldHandle() bool {
 
 func (r RemoveHandler) Handle(m *monitors.Monitors) bool {
 	for _, monitor := range *m {
+        if len(monitor.EmptyDesktops()) == 1 {
+            return true
+        }
 		for _, desktop := range monitor.EmptyDesktops() {
-			if *desktop == monitor.Desktops[len(monitor.Desktops)-1] {
-				continue
-			}
-
 			if r.config.Min >= len(monitor.Desktops) {
 				continue
 			}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -143,6 +143,11 @@ func (r RemoveHandler) Handle(m *monitors.Monitors) bool {
 				continue
 			}
 
+			// TODO: Should we handle desktop destruction if the monitor focus is switched?
+			if !r.config.RemoveFocused && monitor.FocusedDesktopId == desktop.Id {
+				continue
+			}
+
 			err := monitor.RemoveDesktop(desktop.Id)
 			if err != nil {
 				log.Println("Unable to remove desktop: ", desktop.Name, err)

--- a/monitors/monitors.go
+++ b/monitors/monitors.go
@@ -15,6 +15,7 @@ type bspwmState struct {
 type Monitor struct {
 	Name     string
 	Id       int
+	FocusedDesktopId int
 	Desktops []Desktop
 }
 


### PR DESCRIPTION
This will allow you to keep an empty desktop open if you're focused in it
Set `remove-focused = false` in your config.toml to active this feature

Fixes #1 