### PR TITLE
Add support for BSPWM_SOCKET

### DIFF
--- a/ipc/ipc.go
+++ b/ipc/ipc.go
@@ -5,9 +5,11 @@ import (
 	"bytes"
 	"io/ioutil"
 	"net"
+	"os"
 )
 
 const (
+	bspwmSocket = "BSPWM_SOCKET"
 	defaultBspwmSocket = "/tmp/bspwm_0_0-socket"
 )
 
@@ -39,7 +41,11 @@ func NewSubscriber() (*Subscriber, error) {
 }
 
 func newConn() (*net.UnixConn, error) {
-	raddr, err := net.ResolveUnixAddr("unix", defaultBspwmSocket)
+	socketPath := os.Getenv(bspwmSocket)
+	if len(socketPath) == 0 {
+		socketPath = defaultBspwmSocket
+	}
+	raddr, err := net.ResolveUnixAddr("unix", socketPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Support custom bspwm socket path, fallback to default if one isn't set. This allows btops to support scripts like [`bspwm-session`](https://github.com/Chrysostomus/bspwm-scripts/blob/master/bspwm-session) and fixes issue #6.